### PR TITLE
Make file name comments optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,26 @@ This module will check the hash of the source and the current solidity version t
 
 ```bash
 Options:
-  --config-file, -c  Config file
-  --output-js-dir    Output directory where js files will be copied. Default: ./build
-  --output-sol-dir   Output directory where solidity files concatenated without includes will be copied. Default: ./build
-  --solc-version     Solidity version. Example: v0.4.12+commit.194ff033
-  --input, -i        Input files that can be compiled. Default: ./contracts/*.sol
-  --createdir        Create directory if not exist. Default: true. Use --no-createdir to not create a directory
-  --help             Show help
+  --config-file, -c       Config file                                   [string]
+  --output-sol-dir        Output directory where solidity files concatenated
+                          without includes will be copied. Default: ./build
+                                                                        [string]
+  --output-artifacts-dir  Output directory where artifact files will be
+                          generated.                                    [string]
+  --solc-version          Solidity version. Example: v0.4.12+commit.194ff033
+                                                                        [string]
+  --input, -i             Input files that can be compiled. Default:
+                          ./contracts/*.sol                              [array]
+  --createdir             Create directory if not exist. Default: true. Use
+                          --no-createdir to not create a directory     [boolean]
+  --insert-file-names     Insert original file names in the resulting
+                          concatenate files. Use 'imports' to only insert name
+                          in files with imports. Default: all
+                            [choices: "all", "none", "imports"] [default: "all"]
+  --quiet, -q             Silence output and compiler warnings. Default: false
+                                                                       [boolean]
+  --verbose, -v           verbose output. Default: false               [boolean]
+  --help                  Show help                                    [boolean]
 ```
 
 You can use a config file to specify options.

--- a/js/api.js
+++ b/js/api.js
@@ -108,6 +108,7 @@ if (fs.existsSync('./contracts')) {
 const runFromConfigFile = (configFile, overloadOpts, cb) => {
   readConfigFile(configFile, (err, optsFile) => {
     if (err) return cb();
+    if (optsFile.insertFileNames && ['all', 'none', 'imports'].indexOf(optsFile.insertFileNames) > -1) return cb();
     const opts = Object.assign(optsDefault, optsFile, overloadOpts);
     run(opts, cb);
     return null;

--- a/js/cli.js
+++ b/js/cli.js
@@ -30,6 +30,12 @@ const yargs = require('yargs')
     describe: 'Create directory if not exist. Default: true. Use --no-createdir to not create a directory',
     type: 'boolean',
   })
+  .option('insert-file-names', {
+    describe: 'Insert original file names in the resulting concatenate files. ' +
+      'Use \'imports\' to only insert name in files with imports. Default: all',
+    choices: ['all', 'none', 'imports'],
+    default: 'all'
+  })
   .option('quiet', {
     alias: 'q',
     describe: 'Silence output and compiler warnings. Default: false',
@@ -50,7 +56,7 @@ if (yargs.help === true) {
 }
 */
 
-const optsCommandLine = {};
+const optsCommandLine = {insertFileNames: yargs.insertFileNames};
 
 if (yargs.outputJsDir) optsCommandLine.outputJsDir = yargs.outputJsDir;
 if (yargs.outputSolDir) optsCommandLine.outputSolDir = yargs.outputSolDir;
@@ -69,4 +75,3 @@ api.runFromConfigFile(configFile, optsCommandLine, (err) => {
     console.error("ERROR:", err);
   }
 });
-

--- a/js/solcpiler.js
+++ b/js/solcpiler.js
@@ -718,7 +718,10 @@ class Solcpiler {
     const v = this.opts.solcVersion.startsWith('v')
       ? this.opts.solcVersion.slice(1)
       : this.opts.solcVersion;
-    if (this.solc.version().startsWith(v)) return;
+    if (this.solc.version().startsWith(v)) {
+      this.compiledSolcVersion = this.solc.version();
+      return Promise.resolve();
+    }
 
     if (!this.opts.quiet) console.log('setting solc version', this.opts.solcVersion, '\n');
 

--- a/js/solcpiler.js
+++ b/js/solcpiler.js
@@ -380,6 +380,7 @@ class Solcpiler {
   generateFiles(output, sourceFile) {
     const contractFiles = this.resolveImportsFromFile(sourceFile);
     contractFiles.push(sourceFile);
+    const hasImports = contractFiles.length > 1;
 
     const sources = contractFiles
       .map(f => (output.contracts[f] ? f : this.remappings[f]))
@@ -422,7 +423,7 @@ class Solcpiler {
       .replace('.sol', '');
 
     // generate _all.sol file
-    const r = /^import *"(.*)";/gm;
+    const r = /^import *"(.*)";\n/gm;
 
     let sol = '';
     contractFiles.forEach((c) => {
@@ -432,7 +433,15 @@ class Solcpiler {
         contract = this.sources[c] || this.importSources[c];
       }
 
-      sol += `\n\n///File: ${c}\n\n${contract.replace(r, '')}`;
+      let prefix;
+      let suffix;
+      if (this.opts.insertFileNames == 'all' || (hasImports && this.opts.insertFileNames == 'imports')) {
+        prefix = `/* file: ${c} */\n`;
+        suffix = `\n/* eof (${c}) */`
+      } else  {
+        prefix = suffix = '';
+      }
+      sol += `${prefix}${contract.replace(r, '')}${suffix}\n`;
     });
 
     fs.writeFileSync(path.join(this.opts.outputSolDir, `${contractFileName}_all.sol`), sol);


### PR DESCRIPTION
> This PR depends on #12

- Make file names comments in the concatenated file optional
- Add the `--insert-file-names` option
- Update README
- Do not use natspec for file comment
- Add eof comment
- Remove empty line from removed import in concatenated file

Closes #13