### PR TITLE
Removes sources urls when `useLiteralContent` is true

### DIFF
--- a/js/solcpiler.js
+++ b/js/solcpiler.js
@@ -238,6 +238,13 @@ class Solcpiler {
       this.resolveImportsFromFile(f).forEach(addContract);
     });
 
+    // delete source urls if useLiteralContent is true
+    // the urls are deleted afterwards instead of simply not being added as they
+    // are used for
+    if (standardInput.settings.metadata.useLiteralContent) {
+      Object.keys(standardInput.sources).forEach(source => delete standardInput.sources[source].urls);
+    }
+
     this.standardInput = standardInput;
   }
 


### PR DESCRIPTION
> This PR depends on #12 and #14 

This partially addresses #15. It removes sources urls with `useLiteralContent` but it does not add the option to let the user specify custom paths (as mentioned at the end of #15). 