### PR TITLE
Remove trailing newline when concatenating files

### DIFF
--- a/js/solcpiler.js
+++ b/js/solcpiler.js
@@ -445,12 +445,17 @@ class Solcpiler {
       let suffix;
       if (this.opts.insertFileNames == 'all' || (hasImports && this.opts.insertFileNames == 'imports')) {
         prefix = `/* file: ${c} */\n`;
-        suffix = `\n/* eof (${c}) */`
+        suffix = `\n/* eof (${c}) */\n`
       } else  {
-        prefix = suffix = '';
+        prefix = '';
+        suffix = hasImports ? '\n' : '';
       }
-      sol += `${prefix}${contract.replace(r, '')}${suffix}\n`;
+      sol += `${prefix}${contract.replace(r, '')}${suffix}`;
     });
+    // Remove trailing newline inserted when not including file names and the original file has imports.
+    if (hasImports && this.opts.insertFileNames == 'none' && sol.endsWith('\n\n')) {
+      sol = sol.slice(0, -1);
+    }
 
     fs.writeFileSync(path.join(this.opts.outputSolDir, `${contractFileName}_all.sol`), sol);
   }


### PR DESCRIPTION
Remove the trailing newline inserted when concatenating multiple sol
files into a single _all.sol file without including the original file
names.

@perissology I made a mistake in my last PR and there is a new line which is inserted at the end of the file even when the comments with the original file names are not included. The compiled file is therefore not exactly the same. 

Most editors automatically include a newline at the end of a file when saving. With solcpiler this result in an `_all.sol` file with a rather ugly double newline at the end of the file. My bad... This should hopefully fix it.

Ps. thanks for releasing `beta.9` with the previous changes it really helped me out.